### PR TITLE
Adopt Typelevel Code of Conduct org-wide

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # Code of Conduct
 
-Every member of our community has the right to have their identity respected. The Cozydev community is dedicated to providing a positive experience for everyone, regardless of age, gender identity and expression, sexual orientation, disability, neurodivergence, physical appearance, body size, ethnicity, nationality, race, or religion (or lack thereof), education, or socio-economic status.
+Every member of our community has the right to have their identity respected. The CozyDev community is dedicated to providing a positive experience for everyone, regardless of age, gender identity and expression, sexual orientation, disability, neurodivergence, physical appearance, body size, ethnicity, nationality, race, or religion (or lack thereof), education, or socio-economic status.
 
 Everyone is expected to follow the [Typelevel Code of Conduct] when discussing the project on the available communication channels.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,14 @@
+# Code of Conduct
+
+Every member of our community has the right to have their identity respected. The Cozydev community is dedicated to providing a positive experience for everyone, regardless of age, gender identity and expression, sexual orientation, disability, neurodivergence, physical appearance, body size, ethnicity, nationality, race, or religion (or lack thereof), education, or socio-economic status.
+
+Everyone is expected to follow the [Typelevel Code of Conduct] when discussing the project on the available communication channels.
+
+## Moderation
+
+If you have any questions, concerns, or moderation requests, please contact a moderator.
+
+- Sam Pillsworth | [email](mailto:sam@blerf.ca)
+- Andrew Valencik | [email](mailto:andrew.valencik@gmail.com)
+
+[Typelevel Code of Conduct]: https://typelevel.org/code-of-conduct.html


### PR DESCRIPTION
This PR adds a CODE_OF_CONDUCT.md which will be used for all cozydev repos.